### PR TITLE
Add response schema support and JSON result parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Run the demo yourself: [Running the Weatherbit Example (Step-by-Step)](#running-
 
 -   **OpenAPI v2 (Swagger) & v3 Support:** Parses standard specification formats.
 -   **Schema Generation:** Creates MCP tool schemas from OpenAPI operation parameters and request/response definitions.
+-   **Response Schema Parsing:** Output schemas are inferred from successful responses allowing JSON results to be returned in structured form.
 -   **Secure API Key Management:**
     -   Injects API keys into requests (`header`, `query`, `path`, `cookie`) based on command-line configuration.
         -   Loads API keys directly from flags (`--api-key`), environment variables (`--api-key-env`), or `.env` files located alongside local specs.
@@ -47,6 +48,8 @@ Run the demo yourself: [Running the Weatherbit Example (Step-by-Step)](#running-
 -   **Server URL Detection:** Uses server URLs from the spec as the base for tool interactions (can be overridden).
 -   **Filtering:** Options to include/exclude specific operations or tags (`--include-tag`, `--exclude-tag`, `--include-op`, `--exclude-op`).
 -   **Request Header Injection:** Pass custom headers (e.g., for additional auth, tracing) via the `REQUEST_HEADERS` environment variable.
+
+When a tool returns a JSON object containing a `path` field, combine it with the server base URL to form a full download link. For example, if the response is `{ "path": "/files/123" }` and the API base URL is `https://api.example.com`, an LLM can download using `https://api.example.com/files/123`.
 
 ## Installation
 

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -49,9 +49,10 @@ func (ts *ToolSet) GetAPIKeyDetails() (name, in string) {
 
 // Tool represents a single function or capability exposed via MCP.
 type Tool struct {
-	Name        string `json:"name"` // Corresponds to OpenAPI operationId or generated name
-	Description string `json:"description,omitempty"`
-	InputSchema Schema `json:"inputSchema"` // Renamed from Parameters, consolidate parameters/body here
+	Name         string `json:"name"` // Corresponds to OpenAPI operationId or generated name
+	Description  string `json:"description,omitempty"`
+	InputSchema  Schema `json:"inputSchema"` // Renamed from Parameters, consolidate parameters/body here
+	OutputSchema Schema `json:"outputSchema,omitempty"`
 	// Entrypoint  string      `json:"entrypoint"`             // Removed for simplicity, schema should contain enough info?
 	// RequestBody RequestBody `json:"request_body,omitempty"` // Removed, info should be part of InputSchema
 	// HTTPMethod  string      `json:"http_method"`            // Removed for simplicity

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -38,6 +38,13 @@ func createTestToolSetForCall() *mcp.ToolSet {
 					},
 					Required: []string{"user_id"},
 				},
+				OutputSchema: mcp.Schema{
+					Type: "object",
+					Properties: map[string]mcp.Schema{
+						"id": {Type: "string"},
+					},
+					Required: []string{"id"},
+				},
 			},
 			{
 				Name:        "post_data",
@@ -48,6 +55,12 @@ func createTestToolSetForCall() *mcp.ToolSet {
 						"data": {Type: "string"},
 					},
 					Required: []string{"data"},
+				},
+				OutputSchema: mcp.Schema{
+					Type: "object",
+					Properties: map[string]mcp.Schema{
+						"status": {Type: "string"},
+					},
 				},
 			},
 		},
@@ -166,10 +179,14 @@ func TestHttpMethodPostHandler(t *testing.T) {
 				resultPayload, ok := resp.Result.(ToolResultPayload)
 				require.True(t, ok)
 				assert.False(t, resultPayload.IsError)
-				require.Len(t, resultPayload.Content, 1)
+				require.Len(t, resultPayload.Content, 2)
+				assert.Equal(t, "json", resultPayload.Content[0].Type)
 				assert.JSONEq(t, `{"id":"postUser"}`, resultPayload.Content[0].Text)
+				assert.Equal(t, "text", resultPayload.Content[1].Type)
+				assert.Equal(t, "{\"id\":\"postUser\"}\n", resultPayload.Content[1].Text)
 			},
 			mockBackend: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				fmt.Fprintln(w, `{"id":"postUser"}`)
 			},


### PR DESCRIPTION
## Summary
- support `OutputSchema` in tool definitions
- parse response schemas during parsing for OpenAPI v2/v3
- decode JSON responses and include structured output
- document response structure parsing and download URL tips
- test parser and server handling of output schemas

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685a6be9ff1483209882ee1f59abde1d