### PR TITLE
Handle structured content in tool results

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -79,10 +79,11 @@ type ToolResultContent struct {
 
 // ToolResultPayload represents the structure for the 'result' of a 'tool_result' JSON-RPC response.
 type ToolResultPayload struct {
-	Content    []ToolResultContent `json:"content"`                // Array of content items
-	IsError    bool                `json:"isError"`                // Aligning with gin-mcp
-	Error      *MCPError           `json:"error,omitempty"`        // Detailed error info if IsError is true
-	ToolCallID string              `json:"tool_call_id,omitempty"` // Optional: Can be helpful
+	Content           []ToolResultContent `json:"content"` // Array of content items
+	StructuredContent interface{}         `json:"structuredContent,omitempty"`
+	IsError           bool                `json:"isError"`                // Aligning with gin-mcp
+	Error             *MCPError           `json:"error,omitempty"`        // Detailed error info if IsError is true
+	ToolCallID        string              `json:"tool_call_id,omitempty"` // Optional: Can be helpful
 }
 
 // --- Server State ---
@@ -851,10 +852,37 @@ func handleToolCallJSONRPC(connID string, req *jsonRPCRequest, toolSet *mcp.Tool
 				// Successful execution
 				resultContent := []ToolResultContent{{Type: "text", Text: string(bodyBytes)}}
 
-				resultPayload = ToolResultPayload{
-					Content:    resultContent,
-					IsError:    false,
-					ToolCallID: fmt.Sprintf("%v", req.ID),
+				// Determine if this tool has an output schema
+				hasSchema := false
+				for _, t := range toolSet.Tools {
+					if t.Name == params.ToolName {
+						if t.OutputSchema.Type != "" || len(t.OutputSchema.Properties) > 0 {
+							hasSchema = true
+						}
+						break
+					}
+				}
+
+				if hasSchema {
+					var structured interface{}
+					if err := json.Unmarshal(bodyBytes, &structured); err == nil {
+						resultPayload = ToolResultPayload{
+							Content:           resultContent,
+							StructuredContent: structured,
+							ToolCallID:        fmt.Sprintf("%v", req.ID),
+						}
+					} else {
+						log.Printf("Failed to parse response as JSON for tool '%s': %v", params.ToolName, err)
+						resultPayload = ToolResultPayload{
+							Content:    resultContent,
+							ToolCallID: fmt.Sprintf("%v", req.ID),
+						}
+					}
+				} else {
+					resultPayload = ToolResultPayload{
+						Content:    resultContent,
+						ToolCallID: fmt.Sprintf("%v", req.ID),
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- support `StructuredContent` field in `ToolResultPayload`
- attempt JSON parse when tool defines an output schema
- log JSON parse errors without marking the call as failed
- add test for non‑JSON responses with output schemas

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68661383203483208e30b7d92d2e5268