### PR TITLE
Add nullable support for Schema

### DIFF
--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -78,5 +78,7 @@ type Schema struct {
 	Items       *Schema           `json:"items,omitempty"`      // For type "array"
 	Format      string            `json:"format,omitempty"`     // e.g., "int32", "date-time"
 	Enum        []interface{}     `json:"enum,omitempty"`
+	OneOf       []Schema          `json:"oneOf,omitempty"`
+	Nullable    bool              `json:"nullable,omitempty"`
 	// Add other relevant JSON Schema fields as needed (e.g., minimum, maximum, pattern)
 }


### PR DESCRIPTION
## Summary
- support `nullable` in MCP Schema
- propagate nullable values when converting from OpenAPI v3 and Swagger v2 schemas
- add `oneOf` support for mix-type schemas
- expand parser tests for oneOf

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686f8c5f949c83209db76cc40b698411