### PR TITLE
Preserve tool hint false values

### DIFF
--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -63,10 +63,10 @@ type Tool struct {
 // ToolAnnotations captures optional MCP annotation hints for a tool.
 type ToolAnnotations struct {
 	Title           string `json:"title,omitempty"`
-	ReadOnlyHint    bool   `json:"readOnlyHint,omitempty"`
-	DestructiveHint bool   `json:"destructiveHint,omitempty"`
-	IdempotentHint  bool   `json:"idempotentHint,omitempty"`
-	OpenWorldHint   bool   `json:"openWorldHint,omitempty"`
+	ReadOnlyHint    *bool  `json:"readOnlyHint,omitempty"`
+	DestructiveHint *bool  `json:"destructiveHint,omitempty"`
+	IdempotentHint  *bool  `json:"idempotentHint,omitempty"`
+	OpenWorldHint   *bool  `json:"openWorldHint,omitempty"`
 }
 
 // RequestBody describes the expected request body for a tool.


### PR DESCRIPTION
## Summary
- keep MCP tool hints when set to `false`
- update tests for tool hint annotations
- add coverage for `readOnlyHint: false`

## Testing
- `go test ./...`
- `go test ./... -run ToolHints -v`


------
https://chatgpt.com/codex/tasks/task_e_6878a43005b48320b31a8587c417ec0b