### PR TITLE
Add debug flag for conditional logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ The `openapi-mcp` command accepts the following flags:
 | `--base-url`         | Manually override the target API server base URL detected from the spec.                                              | `string`      | (none)                           |
 | `--name`             | Default name for the generated MCP toolset (used if spec has no title).                                             | `string`      | "OpenAPI-MCP Tools"            |
 | `--desc`             | Default description for the generated MCP toolset (used if spec has no description).                                | `string`      | "Tools generated from OpenAPI spec" |
+| `--debug`            | Enable verbose debug logging.                                                         | `bool`        | `false`                         |
 
 **Note:** You can get this list by running the tool with the `--help` flag (e.g., `docker run --rm ckanthony/openapi-mcp:latest --help`).
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ The `openapi-mcp` command accepts the following flags:
 | `--base-url`         | Manually override the target API server base URL detected from the spec.                                              | `string`      | (none)                           |
 | `--name`             | Default name for the generated MCP toolset (used if spec has no title).                                             | `string`      | "OpenAPI-MCP Tools"            |
 | `--desc`             | Default description for the generated MCP toolset (used if spec has no description).                                | `string`      | "Tools generated from OpenAPI spec" |
+| `--timeout-spec`     | Request timeout in seconds for outbound API calls.                                               | `int`         | `30` |
 | `--debug`            | Enable verbose debug logging.                                                         | `bool`        | `false`                         |
 
 **Note:** You can get this list by running the tool with the `--help` flag (e.g., `docker run --rm ckanthony/openapi-mcp:latest --help`).

--- a/cmd/openapi-mcp/main.go
+++ b/cmd/openapi-mcp/main.go
@@ -49,6 +49,7 @@ func main() {
 	serverBaseURL := flag.String("base-url", "", "Manually override the server base URL")
 	defaultToolName := flag.String("name", "OpenAPI-MCP Tools", "Default name for the toolset")
 	defaultToolDesc := flag.String("desc", "Tools generated from OpenAPI spec", "Default description for the toolset")
+	timeoutSpec := flag.Int("timeout-spec", 30, "Request timeout in seconds for outbound API calls")
 	debug := flag.Bool("debug", false, "Enable verbose debug logging")
 
 	// Parse flags *after* defining them all
@@ -119,6 +120,7 @@ func main() {
 		DefaultToolName:   *defaultToolName,
 		DefaultToolDesc:   *defaultToolDesc,
 		CustomHeaders:     customHeadersEnv,
+		TimeoutSpec:       *timeoutSpec,
 		Debug:             *debug,
 	}
 

--- a/cmd/openapi-mcp/main.go
+++ b/cmd/openapi-mcp/main.go
@@ -49,6 +49,7 @@ func main() {
 	serverBaseURL := flag.String("base-url", "", "Manually override the server base URL")
 	defaultToolName := flag.String("name", "OpenAPI-MCP Tools", "Default name for the toolset")
 	defaultToolDesc := flag.String("desc", "Tools generated from OpenAPI spec", "Default description for the toolset")
+	debug := flag.Bool("debug", false, "Enable verbose debug logging")
 
 	// Parse flags *after* defining them all
 	flag.Parse()
@@ -118,6 +119,7 @@ func main() {
 		DefaultToolName:   *defaultToolName,
 		DefaultToolDesc:   *defaultToolDesc,
 		CustomHeaders:     customHeadersEnv,
+		Debug:             *debug,
 	}
 
 	log.Printf("Configuration loaded: %+v\n", cfg)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,6 +40,9 @@ type Config struct {
 	// Server-side request modification
 	CustomHeaders string // Comma-separated list of headers (e.g., "Header1:Value1,Header2:Value2") to add to outgoing requests.
 
+	// HTTP request timeout in seconds for outbound API calls
+	TimeoutSpec int
+
 	// Debug logging
 	Debug bool // Enable verbose debug logging
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,6 +39,9 @@ type Config struct {
 
 	// Server-side request modification
 	CustomHeaders string // Comma-separated list of headers (e.g., "Header1:Value1,Header2:Value2") to add to outgoing requests.
+
+	// Debug logging
+	Debug bool // Enable verbose debug logging
 }
 
 // GetAPIKey resolves the API key value, prioritizing the environment variable over the direct flag.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -785,7 +785,11 @@ func executeToolCall(params *ToolCallParams, toolSet *mcp.ToolSet, cfg *config.C
 
 	// --- Execute HTTP Request ---
 	log.Printf("[ExecuteToolCall] Sending request with headers: %v", req.Header)
-	client := &http.Client{Timeout: 30 * time.Second}
+	timeout := time.Duration(cfg.TimeoutSpec)
+	if timeout <= 0 {
+		timeout = 30
+	}
+	client := &http.Client{Timeout: timeout * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
 		log.Printf("[ExecuteToolCall] Error executing HTTP request: %v", err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -116,7 +116,7 @@ func ServeMCP(addr string, toolSet *mcp.ToolSet, cfg *config.Config) error {
 		}
 
 		if r.Method == http.MethodGet {
-			httpMethodGetHandler(w, r) // Handle SSE connection setup
+			httpMethodGetHandler(w, r, cfg) // Handle SSE connection setup
 		} else if r.Method == http.MethodPost {
 			httpMethodPostHandler(w, r, toolSet, cfg) // Pass the cfg object here
 		} else {
@@ -134,9 +134,15 @@ func ServeMCP(addr string, toolSet *mcp.ToolSet, cfg *config.Config) error {
 }
 
 // httpMethodGetHandler handles the initial GET request to establish the SSE connection.
-func httpMethodGetHandler(w http.ResponseWriter, r *http.Request) {
+func httpMethodGetHandler(w http.ResponseWriter, r *http.Request, cfg *config.Config) {
 	connectionID := uuid.New().String()
 	log.Printf("SSE client connecting: %s (Assigning ID: %s)", r.RemoteAddr, connectionID)
+
+	if cfg != nil && cfg.Debug {
+		if hdr, err := json.Marshal(r.Header); err == nil {
+			log.Printf("DEBUG: GET request headers: %s", string(hdr))
+		}
+	}
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {
@@ -300,6 +306,11 @@ func writeSSEEvent(w http.ResponseWriter, eventName string, data interface{}) er
 // httpMethodPostHandler handles incoming POST requests containing MCP messages.
 func httpMethodPostHandler(w http.ResponseWriter, r *http.Request, toolSet *mcp.ToolSet, cfg *config.Config) {
 	// --- Original Logic (Restored) ---
+	if cfg != nil && cfg.Debug {
+		if hdr, err := json.Marshal(r.Header); err == nil {
+			log.Printf("DEBUG: POST request headers: %s", string(hdr))
+		}
+	}
 	connID := r.Header.Get("X-Connection-ID") // Try header first
 	if connID == "" {
 		connID = r.URL.Query().Get("sessionId") // Fallback to query parameter
@@ -423,28 +434,40 @@ func httpMethodPostHandler(w http.ResponseWriter, r *http.Request, toolSet *mcp.
 		log.Printf("Processing JSON-RPC message for %s: Method=%s, ID=%v", connID, req.Method, reqID)
 		switch req.Method {
 		case "initialize":
-			incomingInitializeJSON, _ := json.Marshal(req)
-			log.Printf("DEBUG: Handling 'initialize' for %s. Incoming request: %s", connID, string(incomingInitializeJSON))
+			if cfg.Debug {
+				incomingInitializeJSON, _ := json.Marshal(req)
+				log.Printf("DEBUG: Handling 'initialize' for %s. Incoming request: %s", connID, string(incomingInitializeJSON))
+			}
 			respToSend = handleInitializeJSONRPC(connID, &req)
-			outgoingInitializeJSON, _ := json.Marshal(respToSend)
-			log.Printf("DEBUG: Prepared 'initialize' response for %s. Outgoing response: %s", connID, string(outgoingInitializeJSON))
+			if cfg.Debug {
+				outgoingInitializeJSON, _ := json.Marshal(respToSend)
+				log.Printf("DEBUG: Prepared 'initialize' response for %s. Outgoing response: %s", connID, string(outgoingInitializeJSON))
+			}
 		case "notifications/initialized":
 			log.Printf("Received 'notifications/initialized' notification for %s. Ignoring.", connID)
 			w.WriteHeader(http.StatusAccepted)
 			fmt.Fprintln(w, "Notification received.")
 			return // Return early, do not send anything on SSE channel
 		case "tools/list":
-			incomingListJSON, _ := json.MarshalIndent(req, "", "  ")
-			log.Printf("DEBUG: Handling 'tools/list' for %s. Incoming request: %s", connID, string(incomingListJSON))
+			if cfg.Debug {
+				incomingListJSON, _ := json.Marshal(req)
+				log.Printf("DEBUG: Handling 'tools/list' for %s. Incoming request: %s", connID, string(incomingListJSON))
+			}
 			respToSend = handleToolsListJSONRPC(connID, &req, toolSet)
-			outgoingListJSON, _ := json.MarshalIndent(respToSend, "", "  ")
-			log.Printf("DEBUG: Prepared 'tools/list' response for %s. Outgoing response: %s", connID, string(outgoingListJSON))
+			if cfg.Debug {
+				outgoingListJSON, _ := json.Marshal(respToSend)
+				log.Printf("DEBUG: Prepared 'tools/list' response for %s. Outgoing response: %s", connID, string(outgoingListJSON))
+			}
 		case "tools/call":
-			incomingCallJSON, _ := json.MarshalIndent(req, "", "  ")
-			log.Printf("DEBUG: Handling 'tools/call' for %s. Incoming request: %s", connID, string(incomingCallJSON))
+			if cfg.Debug {
+				incomingCallJSON, _ := json.Marshal(req)
+				log.Printf("DEBUG: Handling 'tools/call' for %s. Incoming request: %s", connID, string(incomingCallJSON))
+			}
 			respToSend = handleToolCallJSONRPC(connID, &req, toolSet, cfg, r.Header, r.Cookies())
-			outgoingCallJSON, _ := json.MarshalIndent(respToSend, "", "  ")
-			log.Printf("DEBUG: Prepared 'tools/call' response for %s. Outgoing response: %s", connID, string(outgoingCallJSON))
+			if cfg.Debug {
+				outgoingCallJSON, _ := json.Marshal(respToSend)
+				log.Printf("DEBUG: Prepared 'tools/call' response for %s. Outgoing response: %s", connID, string(outgoingCallJSON))
+			}
 		default:
 			log.Printf("Received unknown JSON-RPC method '%s' for %s", req.Method, connID)
 			respToSend = createJSONRPCError(reqID, -32601, fmt.Sprintf("Method not found: %s", req.Method), nil)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -441,7 +441,7 @@ func TestHttpMethodGetHandler(t *testing.T) {
 		// For the test, we just call cancel() after a short delay
 		// to simulate the connection ending gracefully.
 		time.AfterFunc(100*time.Millisecond, cancel) // Allow handler to start and write initial data
-		httpMethodGetHandler(rr, req)
+		httpMethodGetHandler(rr, req, nil)
 	}()
 
 	// Wait for the handler goroutine to finish.
@@ -1003,7 +1003,7 @@ func TestHttpMethodGetHandler_WriteErrors(t *testing.T) {
 			done := make(chan struct{})
 			go func() {
 				defer close(done)
-				httpMethodGetHandler(mockWriter, req)
+				httpMethodGetHandler(mockWriter, req, nil)
 			}()
 
 			// Wait for the handler goroutine to finish or timeout
@@ -1059,7 +1059,7 @@ func TestHttpMethodGetHandler_GoroutineErrors(t *testing.T) {
 		done := make(chan struct{})
 		go func() {
 			defer close(done)
-			httpMethodGetHandler(mockWriter, req)
+			httpMethodGetHandler(mockWriter, req, nil)
 			log.Println("DEBUG: httpMethodGetHandler goroutine exited")
 		}()
 


### PR DESCRIPTION
## Summary
- allow running with `--debug` to emit debug logs
- print GET/POST request headers when debug flag is used
- show tool list/call JSON logs only in debug mode
- document new `--debug` command-line option

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68883e67f3088320b2561eb6219a2df5