### PR TITLE
Add configurable timeout-spec flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ The `openapi-mcp` command accepts the following flags:
 | `--base-url`         | Manually override the target API server base URL detected from the spec.                                              | `string`      | (none)                           |
 | `--name`             | Default name for the generated MCP toolset (used if spec has no title).                                             | `string`      | "OpenAPI-MCP Tools"            |
 | `--desc`             | Default description for the generated MCP toolset (used if spec has no description).                                | `string`      | "Tools generated from OpenAPI spec" |
+| `--timeout-spec`     | Request timeout in seconds for outbound API calls.                                               | `int`         | `30` |
 | `--debug`            | Enable verbose debug logging.                                                         | `bool`        | `false`                         |
 
 **Note:** You can get this list by running the tool with the `--help` flag (e.g., `docker run --rm ckanthony/openapi-mcp:latest --help`).

--- a/cmd/openapi-mcp/main.go
+++ b/cmd/openapi-mcp/main.go
@@ -49,6 +49,7 @@ func main() {
 	serverBaseURL := flag.String("base-url", "", "Manually override the server base URL")
 	defaultToolName := flag.String("name", "OpenAPI-MCP Tools", "Default name for the toolset")
 	defaultToolDesc := flag.String("desc", "Tools generated from OpenAPI spec", "Default description for the toolset")
+	timeoutSpec := flag.Int("timeout-spec", 30, "Request timeout in seconds for outbound API calls")
 	debug := flag.Bool("debug", false, "Enable verbose debug logging")
 
 	// Parse flags *after* defining them all
@@ -119,6 +120,7 @@ func main() {
 		DefaultToolName:   *defaultToolName,
 		DefaultToolDesc:   *defaultToolDesc,
 		CustomHeaders:     customHeadersEnv,
+		TimeoutSpec:       *timeoutSpec,
 		Debug:             *debug,
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,6 +40,9 @@ type Config struct {
 	// Server-side request modification
 	CustomHeaders string // Comma-separated list of headers (e.g., "Header1:Value1,Header2:Value2") to add to outgoing requests.
 
+	// HTTP request timeout in seconds for outbound API calls
+	TimeoutSpec int
+
 	// Debug logging
 	Debug bool // Enable verbose debug logging
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -785,7 +785,11 @@ func executeToolCall(params *ToolCallParams, toolSet *mcp.ToolSet, cfg *config.C
 
 	// --- Execute HTTP Request ---
 	log.Printf("[ExecuteToolCall] Sending request with headers: %v", req.Header)
-	client := &http.Client{Timeout: 30 * time.Second}
+	timeout := time.Duration(cfg.TimeoutSpec)
+	if timeout <= 0 {
+		timeout = 30
+	}
+	client := &http.Client{Timeout: timeout * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
 		log.Printf("[ExecuteToolCall] Error executing HTTP request: %v", err)


### PR DESCRIPTION
## Summary
- 新增 `--timeout-spec` 指令列參數，預設 30 秒
- `Config` 新增 `TimeoutSpec` 欄位
- `ServeMCP` 使用此設定作為 HTTP 請求的 timeout
- README 更新旗標說明

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688840aac2ec8320af7c887da046a749