### PR TITLE
打印啟動設定

### DIFF
--- a/cmd/openapi-mcp/main.go
+++ b/cmd/openapi-mcp/main.go
@@ -140,6 +140,10 @@ func main() {
 	}
 	log.Printf("MCP toolset generated with %d tools.\n", len(toolSet.Tools))
 
+	// --- Display final runtime settings ---
+	log.Printf("TimeoutSpec (seconds): %d", cfg.TimeoutSpec)
+	log.Printf("Debug mode enabled: %v", cfg.Debug)
+
 	// --- Start Server ---
 	addr := fmt.Sprintf(":%d", *port)
 	log.Printf("Starting MCP server on %s...", addr)


### PR DESCRIPTION
## Summary
- 於 `cmd/openapi-mcp/main.go` 新增日誌，啟動伺服器前輸出 `TimeoutSpec` 與 `Debug` 設定值

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68885f85b2508320bb3236d3b9f60954